### PR TITLE
Bump to go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectrekor/rekor-operator
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.1.0


### PR DESCRIPTION
This will likely need a test deploy first (unsure how to do this
myself)

The current version 1.14 is EOL

Signed-off-by: Luke Hinds <lhinds@redhat.com>
