### PR TITLE
all: rename projectrekor org to sigstore

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,7 +1,7 @@
 domain: rekor.dev
 layout: go.kubebuilder.io/v2
 projectName: rekor-operator
-repo: github.com/projectrekor/rekor-operator
+repo: github.com/sigstore/rekor-operator
 resources:
 - group: operator
   kind: Rekor

--- a/controllers/rekor_controller.go
+++ b/controllers/rekor_controller.go
@@ -22,7 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorv1alpha1 "github.com/projectrekor/rekor-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/sigstore/rekor-operator/api/v1alpha1"
 )
 
 // RekorReconciler reconciles a Rekor object

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,7 +28,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1alpha1 "github.com/projectrekor/rekor-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/sigstore/rekor-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/projectrekor/rekor-operator
+module github.com/sigstore/rekor-operator
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	operatorv1alpha1 "github.com/projectrekor/rekor-operator/api/v1alpha1"
-	"github.com/projectrekor/rekor-operator/controllers"
+	operatorv1alpha1 "github.com/sigstore/rekor-operator/api/v1alpha1"
+	"github.com/sigstore/rekor-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
Rename `projectrekor` org to `sigstore`.

#### Summary

Now hosted `sigstore` organization.

#### Ticket Link

N/A

#### Release Note

?