### PR TITLE
remove master branch reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: build
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
#### Summary
- remove master branch reference
branch was renamed from master to main and now it is safe to remove the master reference
